### PR TITLE
New option to allow insecure content for HTTPS sites with certificate errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -156,6 +156,9 @@ usage examples.
                           regex:pattern or plain content. Path can be either
                           relative or absolute with domain.
       -S, --show-source   Show source of links (html) in the report.
+      --allow-insecure-content
+                          Allow insecure content for HTTPS sites with
+                          certificate errors
 
     Performance Options:
       These options can impact the performance of the crawler.
@@ -255,6 +258,9 @@ Check that no HTML pages have a paragraph tag with a pattern:
 
 Check that robots.txt have a Disallow none:
   ``pylinkvalidate.py --check-content-once '/robots.txt,regex:^Disallow:\s*$' http://example.com/``
+
+Allow insecure content for HTTPS sites with certificate errors [SSL: CERTIFICATE_VERIFY_FAILED]
+  ``pylinkvalidate.py --allow-insecure-content https://self-signed.example.com/``
 
 
 API Usage

--- a/pylinkvalidator/crawler.py
+++ b/pylinkvalidator/crawler.py
@@ -828,6 +828,18 @@ def execute_from_config(config, logger):
     if not config.start_urls:
         raise Exception("At least one starting URL must be supplied.")
 
+    if config.options.allow_insecure_content:
+        # Ref: https://www.python.org/dev/peps/pep-0476/#opting-out
+        import ssl
+        try:
+            _create_unverified_https_context = ssl._create_unverified_context
+        except AttributeError:
+            # Legacy Python that doesn't verify HTTPS certificates by default
+            pass
+        else:
+            # Handle target environment that doesn't support HTTPS verification
+            ssl._create_default_https_context = _create_unverified_https_context
+
     if config.options.mode == MODE_THREAD:
         crawler = ThreadSiteCrawler(config, logger)
     elif config.options.mode == MODE_PROCESS:

--- a/pylinkvalidator/models.py
+++ b/pylinkvalidator/models.py
@@ -114,7 +114,8 @@ WorkerInit = namedtuple_with_defaults(
 WorkerConfig = namedtuple_with_defaults(
     "WorkerConfig",
     ["username", "password", "types", "timeout", "parser", "strict_mode",
-     "prefer_server_encoding", "extra_headers", "ignore_bad_tel_urls"])
+     "prefer_server_encoding", "extra_headers", "ignore_bad_tel_urls",
+     "allow_insecure_content"])
 
 
 WorkerInput = namedtuple_with_defaults(
@@ -550,6 +551,10 @@ class Config(UTF8Class):
             "path,<tag attr1=\"val\">regex:content</tag>. "
             "Content can be either regex:pattern or plain content. "
             "Path can be either relative or absolute with domain.")
+        crawler_group.add_option(
+            "--allow-insecure-content", dest="allow_insecure_content",
+            action="store_true", default=False,
+            help="Allow insecure content for HTTPS sites with certificate errors")
 
         # TODO Add follow redirect option.
 


### PR DESCRIPTION
New option to use pylinkvalidator with HTTPS sites with certificate errors, like this example:
error (<class 'urllib2.URLError'>): <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:726)>: https://self-signed.badssl.com

usage: python pylinkvalidate.py --allow-insecure-content https://self-signed.badssl.com